### PR TITLE
Improve ES6 timeseries selector component

### DIFF
--- a/bemserver_ui/static/scripts/modules/components/timeseries/selector.js
+++ b/bemserver_ui/static/scripts/modules/components/timeseries/selector.js
@@ -165,6 +165,8 @@ export class TimeseriesSelector extends HTMLDivElement {
 
     #selectedItemsContainerElmt = null;
     #selectedItems = [];
+    #dropdownSearchPanelElmt = null;
+    #bsDropdownSearchPanel = null;
 
     #searchInputElmt = null;
 
@@ -223,6 +225,8 @@ export class TimeseriesSelector extends HTMLDivElement {
         this.#messagesElmt = document.getElementById("messages");
 
         this.#selectedItemsContainerElmt = document.getElementById("selectedItemsContainer");
+        this.#dropdownSearchPanelElmt = document.getElementById("dropdownSearchPanel");
+        this.#bsDropdownSearchPanel = bootstrap.Dropdown.getOrCreateInstance(this.#dropdownSearchPanelElmt);
 
         this.#searchInputElmt = document.getElementById("search");
 
@@ -613,6 +617,9 @@ export class TimeseriesSelector extends HTMLDivElement {
 
                         searchResultItem.addEventListener("toggle", (event) => {
                             event.preventDefault();
+
+                            // Update dropdown-menu position, taking in account selected items container height.
+                            this.#dropdownSearchPanelElmt.style.transform = `translate(0px, ${this.#selectedItemsContainerElmt.offsetHeight + this.#bsDropdownSearchPanel._config.offset[1]}px)`;
 
                             let toggleEvent = new CustomEvent("toggleItem", { detail: event.detail, bubbles: true});
                             this.dispatchEvent(toggleEvent);

--- a/bemserver_ui/templates/components/timeseries/selector.html
+++ b/bemserver_ui/templates/components/timeseries/selector.html
@@ -5,11 +5,11 @@
     </div>
     <div class="btn-group bg-white w-100">
         <div id="selectedItemsContainer" class="d-flex flex-wrap align-items-center border border-secondary bg-secondary bg-opacity-25 rounded-start w-100 gap-2 p-2 px-3"></div>
-        <button id="dropdownSearchBtn" type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split g-1" data-bs-toggle="dropdown" data-bs-auto-close="false" data-bs-reference="parent" aria-expanded="false">
+        <button id="dropdownSearchBtn" type="button" class="btn btn-outline-secondary dropdown-toggle dropdown-toggle-split g-1" data-bs-toggle="dropdown" data-bs-auto-close="outside" data-bs-reference="parent" aria-expanded="false">
             <i class="bi bi-search"></i>
             <span class="visually-hidden">Toggle search panel</span>
         </button>
-        <div class="dropdown-menu shadow w-100 p-4" aria-labelledby="dropdownBtnSearch">
+        <div id="dropdownSearchPanel" class="dropdown-menu shadow w-100 p-4" aria-labelledby="dropdownSearchBtn">
             <div class="d-flex align-items-center gap-2 mb-2">
                 <input type="text" class="form-control" id="search" name="search" placeholder="Search..." aria-label="Search" aria-describedby="search" autofocus>
                 <a id="clearSearchBtn" role="button" class="link-danger text-decoration-none" title="Clear search filter"><i class="bi bi-x-circle"></i></a>


### PR DESCRIPTION
- Fix search/selection panel to stay below selected timeseries container when it grows and occupies several lines
- Make search/selection panel disappears if focus lost (click outside for example)