### PR TITLE
Improve timeseries selector component (preset search filters)

### DIFF
--- a/bemserver_ui/static/scripts/modules/components/filterSelect.js
+++ b/bemserver_ui/static/scripts/modules/components/filterSelect.js
@@ -57,6 +57,7 @@ export class FilterSelect extends HTMLSelectElement {
         }
 
         this.selectedIndex = Parser.parseIntOrDefault(selectedOptionIndex, this.#defaultOptionIndex);
+        this.#update();
     }
 
     reset() {

--- a/bemserver_ui/static/scripts/modules/views/analysis/energyConsumptionConfig.js
+++ b/bemserver_ui/static/scripts/modules/views/analysis/energyConsumptionConfig.js
@@ -2,6 +2,7 @@ import { InternalAPIRequest } from "../../tools/fetcher.js";
 import { flaskES6 } from "../../../app.js";
 import { ModalConfirm } from "../../components/modalConfirm.js";
 import { FlashMessageTypes, FlashMessage } from "../../components/flash.js";
+import { TimeseriesSelector } from  "../../components/timeseries/selector.js";
 
 
 export class EnergyConsumptionConfigView {
@@ -36,14 +37,17 @@ export class EnergyConsumptionConfigView {
     #editedEnergyUseNameElmt = null;
     #editedWhFactorInputElmt = null;
 
-    constructor(structuralElement, enerConsConfig, energySources, energyUses, availableEnergySources, tsSelector, isEditable) {
+    constructor(structuralElement, enerConsConfig, energySources, energyUses, availableEnergySources, isEditable) {
         this.#structuralElement = structuralElement;
         this.#config = enerConsConfig;
         this.#energySources = energySources;
         this.#energyUses = energyUses;
         this.#availableEnergySources = availableEnergySources;
-        this.#tsSelector = tsSelector;
         this.#isEditable = isEditable;
+
+        if (this.#isEditable) {
+            this.#tsSelector = TimeseriesSelector.getInstance("tsSelectorConfig");
+        }
 
         this.#cacheDOM();
         this.#initEventListeners();

--- a/bemserver_ui/static/scripts/modules/views/timeseries/dataCompleteness.js
+++ b/bemserver_ui/static/scripts/modules/views/timeseries/dataCompleteness.js
@@ -3,6 +3,7 @@ import { flaskES6 } from "../../../app.js";
 import { FlashMessageTypes, FlashMessage } from "../../components/flash.js";
 import { TimeseriesCompletenessChart } from "../../components/tsCompChart.js";
 import { Spinner } from "../../components/spinner.js";
+import { TimeseriesSelector } from "../../components/timeseries/selector.js";
 
 
 export class TimeSeriesDataCompletenessView {
@@ -28,8 +29,8 @@ export class TimeSeriesDataCompletenessView {
 
     #tsSelector = null;
 
-    constructor(tsSelector, options = { height: 400 }) {
-        this.#tsSelector = tsSelector;
+    constructor(options = { height: 400 }) {
+        this.#tsSelector = TimeseriesSelector.getInstance("tsSelectorCompleteness");
 
         this.#cacheDOM();
         this.#initElements();

--- a/bemserver_ui/static/scripts/modules/views/timeseries/dataExplore.js
+++ b/bemserver_ui/static/scripts/modules/views/timeseries/dataExplore.js
@@ -3,6 +3,7 @@ import { flaskES6 } from "../../../app.js";
 import { FlashMessageTypes, FlashMessage } from "../../components/flash.js";
 import { TimeseriesChart } from "../../components/tsChart.js";
 import { Spinner } from "../../components/spinner.js";
+import { TimeseriesSelector } from "../../components/timeseries/selector.js";
 
 
 export class TimeseriesDataExploreView {
@@ -26,8 +27,8 @@ export class TimeseriesDataExploreView {
     #chart = null;
     #tsSelector = null;
 
-    constructor(tsSelector, options = { height: 400 }) {
-        this.#tsSelector = tsSelector;
+    constructor(options = { height: 400 }) {
+        this.#tsSelector = TimeseriesSelector.getInstance("tsSelectorExplore");
 
         this.#cacheDOM();
         this.#initElements();

--- a/bemserver_ui/static/scripts/modules/views/timeseries/delete.js
+++ b/bemserver_ui/static/scripts/modules/views/timeseries/delete.js
@@ -2,6 +2,7 @@ import { FlashMessageTypes, FlashMessage } from "../../components/flash.js";
 import { ModalConfirm } from "../../components/modalConfirm.js";
 import { InternalAPIRequest } from "../../tools/fetcher.js";
 import { flaskES6 } from "../../../app.js";
+import { TimeseriesSelector } from "../../components/timeseries/selector.js";
 
 
 export class TimeseriesDeleteView {
@@ -20,8 +21,8 @@ export class TimeseriesDeleteView {
 
     #tsSelector = null;
 
-    constructor(tsSelector) {
-        this.#tsSelector = tsSelector;
+    constructor() {
+        this.#tsSelector = TimeseriesSelector.getInstance("tsSelectorDelete");
 
         this.#internalAPIRequester = new InternalAPIRequest();
 

--- a/bemserver_ui/templates/macros/components/ts_selector.html
+++ b/bemserver_ui/templates/macros/components/ts_selector.html
@@ -1,4 +1,5 @@
-<div>
+{% macro render_ts_selector(element_id=none, selection_limit=-1, filters={}) %}
+<div is="app-ts-selector"{% if element_id %} id="{{ element_id }}"{% endif %} selection-limit="{{ selection_limit }}"{% for filter_name, filter_value in filters.items() %} {{ filter_name }}={{ filter_value }}{% endfor %}>
     <div class="d-flex justify-content-between align-items-start gap-2">
         <h5>Timeseries selection</h5>
         <small id="countResultsSelected" class="text-muted"></small>
@@ -39,3 +40,4 @@
         </div>
     </div>
 </div>
+{% endmacro %}

--- a/bemserver_ui/templates/pages/analysis/energy_consumption/config.html
+++ b/bemserver_ui/templates/pages/analysis/energy_consumption/config.html
@@ -1,4 +1,5 @@
 {% import "macros/items_count.html" as mac_items_count %}
+{% import "macros/components/ts_selector.html" as mac_ts_selector %}
 {% extends "pages/base.html" %}
 
 {% set title = "Energy consumption" %}
@@ -55,7 +56,7 @@
                                 <div class="collapse" id="addEnergySourceHelpCollapsePanel">
                                     <div class="alert alert-info mb-0 pb-0" role="alert" style="max-width: 700px;">
                                         <span class="fw-bold"><i class="bi bi-question-diamond"></i> Help</span>
-                                        <p>You can <span class="fw-bold">add an energy source</span> to select <span class="fw-bold">timeseries that defines energy end uses</span>.</p>
+                                        <p>You can <span class="fw-bold">add an energy source</span> to select the <span class="fw-bold">timeseries that defines energy end uses</span>.</p>
                                     </div>
                                 </div>
                             </td>
@@ -69,15 +70,15 @@
 </div>
 {% if is_editable %}
 <div class="modal fade" id="selectTimeseries" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="selectTimeseriesLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-dialog modal-xl modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="selectTimeseriesLabel">Energy consumption configuration [<span id="editedEnergySourceName"></span>] [<span id="editedEnergyUseName"></span>]</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                {% filter indent(width=16, first=True) %}
-                {% include "components/timeseries/selector.html" %}
+                {% filter indent(width=16, first=False) %}
+                {{ mac_ts_selector.render_ts_selector(element_id="tsSelectorConfig", filters={structural_element.type: structural_element.id}) -}}
                 {% endfilter %}
                 <div class="mt-3">
                     <label for="editedWhFactor" class="form-label">Wh conversion factor</label>
@@ -100,19 +101,10 @@
 {{ super() -}}
 {% filter indent(width=8, first=True) %}
 <script type="module">
-    import { TimeseriesSelector } from "{{ url_for('static', filename='scripts/modules/components/timeseries/selector.js') }}";
     import { EnergyConsumptionConfigView } from "{{ url_for('static', filename='scripts/modules/views/analysis/energyConsumptionConfig.js') }}";
 
 
     document.addEventListener("DOMContentLoaded", () => {
-
-        let isEditable = {{ is_editable | tojson }};
-
-        let tsSelector = null;
-        if (isEditable) {
-            tsSelector = new TimeseriesSelector({ allowedSelectionLimit: 1 });
-            tsSelector.refresh();
-        }
 
         let energyConsConfigView = new EnergyConsumptionConfigView(
             {{ structural_element | tojson }},
@@ -120,8 +112,7 @@
             {{ all_energy_sources | tojson }},
             {{ all_energy_end_uses | tojson }},
             {{ available_energy_sources | tojson }},
-            tsSelector,
-            isEditable,
+            {{ is_editable | tojson }},
         );
         energyConsConfigView.refresh();
 

--- a/bemserver_ui/templates/pages/timeseries/data/completeness.html
+++ b/bemserver_ui/templates/pages/timeseries/data/completeness.html
@@ -1,3 +1,4 @@
+{% import "macros/components/ts_selector.html" as mac_ts_selector %}
 {% extends "pages/base.html" %}
 
 {% set title = "Data completeness" %}
@@ -9,8 +10,8 @@
         <div class="col">
             <div class="row mb-3">
                 <div class="col">
-                    {% filter indent(width=20, first=True) %}
-                    {% include "components/timeseries/selector.html" %}
+                    {% filter indent(width=20, first=False) %}
+                    {{ mac_ts_selector.render_ts_selector(element_id="tsSelectorCompleteness") -}}
                     {% endfilter %}
                 </div>
             </div>
@@ -68,16 +69,12 @@
     import "{{ url_for('static', filename='scripts/modules/components/time/tzPicker.js') }}";
     import "{{ url_for('static', filename='scripts/modules/components/time/datetimePicker.js') }}";
     import "{{ url_for('static', filename='scripts/modules/components/spinner.js') }}";
-    import { TimeseriesSelector } from "{{ url_for('static', filename='scripts/modules/components/timeseries/selector.js') }}";
     import { TimeSeriesDataCompletenessView } from "{{ url_for('static', filename='scripts/modules/views/timeseries/dataCompleteness.js') }}";
 
 
     document.addEventListener("DOMContentLoaded", () => {
 
-        let tsSelector = new TimeseriesSelector();
-        tsSelector.refresh();
-
-        let tsDataCompletenessView = new TimeSeriesDataCompletenessView(tsSelector, {height: 500});
+        let tsDataCompletenessView = new TimeSeriesDataCompletenessView({height: 500});
         tsDataCompletenessView.refresh();
 
     });

--- a/bemserver_ui/templates/pages/timeseries/data/delete.html
+++ b/bemserver_ui/templates/pages/timeseries/data/delete.html
@@ -1,3 +1,4 @@
+{% import "macros/components/ts_selector.html" as mac_ts_selector %}
 {% extends "pages/base.html" %}
 
 {% set title = "Delete timeseries data" %}
@@ -22,8 +23,8 @@
     </div>
     <div class="row mb-3">
         <div class="col">
-            {% filter indent(width=12, first=True) %}
-            {% include "components/timeseries/selector.html" %}
+            {% filter indent(width=12, first=False) %}
+            {{ mac_ts_selector.render_ts_selector(element_id="tsSelectorDelete") -}}
             {% endfilter %}
         </div>
     </div>
@@ -70,7 +71,6 @@
 {{ super() -}}
 {% filter indent(width=8, first=True) %}
 <script type="module">
-    import { TimeseriesSelector } from "{{ url_for('static', filename='scripts/modules/components/timeseries/selector.js') }}";
     import { TimeseriesDeleteView } from "{{ url_for('static', filename='scripts/modules/views/timeseries/delete.js') }}";
     import "{{ url_for('static', filename='scripts/modules/components/time/tzPicker.js') }}";
     import "{{ url_for('static', filename='scripts/modules/components/time/datetimePicker.js') }}";
@@ -79,10 +79,7 @@
 
     document.addEventListener("DOMContentLoaded", () => {
 
-        let tsSelector = new TimeseriesSelector();
-        tsSelector.refresh();
-
-        let tsDeleteView = new TimeseriesDeleteView(tsSelector);
+        let tsDeleteView = new TimeseriesDeleteView();
         tsDeleteView.refresh();
 
     });

--- a/bemserver_ui/templates/pages/timeseries/data/explore.html
+++ b/bemserver_ui/templates/pages/timeseries/data/explore.html
@@ -1,3 +1,4 @@
+{% import "macros/components/ts_selector.html" as mac_ts_selector %}
 {% extends "pages/base.html" %}
 
 {% set title = "Explore timeseries" %}
@@ -9,8 +10,8 @@
         <div class="col">
             <div class="row mb-3">
                 <div class="col">
-                    {% filter indent(width=20, first=True) %}
-                    {% include "components/timeseries/selector.html" %}
+                    {% filter indent(width=20, first=False) %}
+                    {{ mac_ts_selector.render_ts_selector(element_id="tsSelectorExplore") -}}
                     {% endfilter %}
                 </div>
             </div>
@@ -79,16 +80,12 @@
     import "{{ url_for('static', filename='scripts/modules/components/time/datetimePicker.js') }}";
     import "{{ url_for('static', filename='scripts/modules/components/timeseries/bucketWidth.js') }}";
     import "{{ url_for('static', filename='scripts/modules/components/spinner.js') }}";
-    import { TimeseriesSelector } from "{{ url_for('static', filename='scripts/modules/components/timeseries/selector.js') }}";
     import { TimeseriesDataExploreView } from "{{ url_for('static', filename='scripts/modules/views/timeseries/dataExplore.js') }}";
 
 
     document.addEventListener("DOMContentLoaded", () => {
 
-        let tsSelector = new TimeseriesSelector();
-        tsSelector.refresh();
-
-        let tsDataExploreView = new TimeseriesDataExploreView(tsSelector);
+        let tsDataExploreView = new TimeseriesDataExploreView();
         tsDataExploreView.refresh();
 
     });


### PR DESCRIPTION
- Update fetcher tool to execute many get request at the same time and execute a unique resolve callback.
- Replace timeseries selector jinja template with a macro.
- Add HTML attributes to timeseries selector component in order to preset search filters (campaign-scope, site, building, storey, space and zone).
- Adapt all pages where timeseries selector is used.