### PR TITLE
Fix service cleanup state access

### DIFF
--- a/bemserver_ui/templates/components/sidebar.html
+++ b/bemserver_ui/templates/components/sidebar.html
@@ -120,7 +120,7 @@
                             <ul class="nav nav-pills flex-column gap-1">
                                 <li class="nav-item">
                                     <div class="d-flex justify-content-between align-items-center gap-1">
-                                        <a class="nav-link w-100" href="{{ url_for('services.cleanup.manage_campaign', id=g.campaign_ctxt.id) }}" title="Cleanup service"><i class="bi bi-magic"></i> Cleanup</a>
+                                        <a class="nav-link w-100" href="{{ url_for('services.cleanup.state') }}" title="Cleanup service"><i class="bi bi-magic"></i> Cleanup</a>
                                     </div>
                                 </li>
                             </ul>

--- a/bemserver_ui/templates/pages/services/cleanup/list.html
+++ b/bemserver_ui/templates/pages/services/cleanup/list.html
@@ -53,9 +53,11 @@
             <div class="list-group">
                 {% for x in cleanup_campaigns %}
                 {% set is_campaign_selected = g.campaign_ctxt.has_campaign and g.campaign_ctxt.id|string == x.campaign_id|string %}
-                {% set manage_url = url_for('services.cleanup.manage_campaign', id=x.campaign_id) %}
-                {% if x.id is not none %}
-                    {% set manage_url = url_for("services.cleanup.manage", id=x.id) %}
+                {% set manage_url = url_for('services.cleanup.campaign_state', id=x.campaign_id) %}
+                {% if is_campaign_selected %}
+                    {% set manage_url = url_for("services.cleanup.state") %}
+                {% elif x.id is not none %}
+                    {% set manage_url = url_for("services.cleanup.cleanup_state", id=x.id) %}
                 {% endif %}
                 <a class="list-group-item list-group-item-action d-flex gap-3 py-3{% if is_campaign_selected %} app-campaign-selected{% endif %}" href="{{ manage_url }}" title="Manage campaign cleanup">
                     <i class="bi bi-puzzle"></i>


### PR DESCRIPTION
Previously the cleanup service state page for a campaign not always follow application campaign context.
If user is watching the cleanup service state for his current campaign in app context, he select another campaign as context, the current cleanup service state page was not refreshed.

Things are working better now.