### PR TITLE
Fix sites tree load at degree days analysis page init

### DIFF
--- a/bemserver_ui/templates/pages/analysis/degree_days.html
+++ b/bemserver_ui/templates/pages/analysis/degree_days.html
@@ -95,6 +95,6 @@
 {% block body_scripts %}
 {{ super() -}}
 {% filter indent(width=8, first=True) %}
-<script type="module" src="{{ url_for('static', filename='scripts/modules/views/analysis/degreeDays.js') }}" async></script>
+<script type="module" src="{{ url_for('static', filename='scripts/modules/views/analysis/degreeDays.js') }}" defer></script>
 {% endfilter %}
 {% endblock body_scripts %}


### PR DESCRIPTION
Change the way that degree days analysis script is defined and loaded in page (async -> defer).