### PR TITLE
Fix multiline description

### DIFF
--- a/src/bemserver_ui/extensions/jinja_custom_filters.py
+++ b/src/bemserver_ui/extensions/jinja_custom_filters.py
@@ -2,6 +2,8 @@
 
 import zoneinfo
 
+from markupsafe import Markup, escape
+
 from bemserver_ui.common.exceptions import BEMServerUICommonInvalidDatetimeError
 from bemserver_ui.common.time import convert_from_iso
 
@@ -31,3 +33,15 @@ def init_app(app):
     def is_dict(obj_instance):
         """Test if an object instance is of dictionary type."""
         return isinstance(obj_instance, dict)
+
+    @app.template_filter("crlf2html")
+    def crlf2html(value):
+        """Securely replace all carriage return ("\r") and new line characters ("\n").
+
+        "&#13;" replaces "\r"
+        "&#10;" replaces "\n"
+        """
+        safe_value = str(escape(value))
+        formatted_value = safe_value.replace("\r", "&#13;")
+        formatted_value = formatted_value.replace("\n", "&#10;")
+        return Markup(formatted_value)

--- a/src/bemserver_ui/static/scripts/modules/views/analysis/weather.js
+++ b/src/bemserver_ui/static/scripts/modules/views/analysis/weather.js
@@ -234,7 +234,7 @@ export class WeatherExploreView {
                 paramContainerElmt.appendChild(paramName);
 
                 let tsDescription = document.createElement("small");
-                tsDescription.classList.add("text-muted");
+                tsDescription.classList.add("text-muted", "multiline");
                 tsDescription.textContent = weatherParamData.timeseries.description;
                 paramContainerElmt.appendChild(tsDescription);
 

--- a/src/bemserver_ui/static/scripts/modules/views/events/edit.js
+++ b/src/bemserver_ui/static/scripts/modules/views/events/edit.js
@@ -440,7 +440,7 @@ export class EventEditView {
         }
 
         let tsDescElmt = document.createElement("small");
-        tsDescElmt.classList.add("fst-italic", "text-muted");
+        tsDescElmt.classList.add("fst-italic", "text-muted", "multiline");
         tsDescElmt.innerText = tsData.description;
         tsInnerContainerElmt.appendChild(tsDescElmt);
 

--- a/src/bemserver_ui/static/scripts/modules/views/structuralElements/explore.js
+++ b/src/bemserver_ui/static/scripts/modules/views/structuralElements/explore.js
@@ -315,7 +315,7 @@ export class StructuralElementsExploreView {
         }
 
         let descElmt = document.createElement("small");
-        descElmt.classList.add("fst-italic", "text-muted", "text-break");
+        descElmt.classList.add("fst-italic", "text-muted", "text-break", "multiline");
         descElmt.textContent = data.structural_element.description;
         this.#generalTabContentElmt.appendChild(descElmt);
 

--- a/src/bemserver_ui/static/styles/main.css
+++ b/src/bemserver_ui/static/styles/main.css
@@ -37,3 +37,7 @@ input[type=number].input-number-hide-arrows::-webkit-inner-spin-button {
 .app-flash-message .progress {
     height: 2px !important;
 }
+
+.multiline {
+    white-space: pre-line !important;
+}

--- a/src/bemserver_ui/templates/pages/campaign_scopes/edit.html
+++ b/src/bemserver_ui/templates/pages/campaign_scopes/edit.html
@@ -42,7 +42,7 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label" for="description">Description</label>
-                    <textarea form="editForm" class="form-control" id="description" name="description" rows="3">{{ campaign_scope.description }}</textarea>
+                    <textarea form="editForm" class="form-control" id="description" name="description" rows="3">{{ campaign_scope.description | crlf2html }}</textarea>
                 </div>
                 <div class="d-flex justify-content-end gap-2">
                     <a href="{{ url_for('campaign_scopes.view', id=campaign_scope.id) }}" class="btn btn-outline-secondary btn-sm text-break" title="Cancel">Cancel</a>

--- a/src/bemserver_ui/templates/pages/campaign_scopes/view.html
+++ b/src/bemserver_ui/templates/pages/campaign_scopes/view.html
@@ -47,7 +47,7 @@
                             <dt>Name</dt>
                             <dd class="text-break">{{ campaign_scope.name }}</dd>
                             <dt>Description</dt>
-                            <dd class="text-break">{{ campaign_scope.description | default("-", true) }}</dd>
+                            <dd class="text-break multiline">{{ campaign_scope.description | crlf2html | default("-", true) }}</dd>
                         </dl>
                         {% if signed_user.is_admin %}
                         <div class="order-0 order-lg-1 text-end">

--- a/src/bemserver_ui/templates/pages/campaigns/edit.html
+++ b/src/bemserver_ui/templates/pages/campaigns/edit.html
@@ -68,7 +68,7 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label" for="description">Description</label>
-                    <textarea form="editForm" class="form-control" id="description" name="description" maxlength="500" rows="3">{{ campaign.description }}</textarea>
+                    <textarea form="editForm" class="form-control" id="description" name="description" maxlength="500" rows="3">{{ campaign.description | crlf2html }}</textarea>
                 </div>
                 <div class="d-flex justify-content-end gap-2">
                     <a href="{{ url_for('campaigns.view', id=campaign.id) }}" class="btn btn-outline-secondary btn-sm text-break" title="Cancel">Cancel</a>

--- a/src/bemserver_ui/templates/pages/campaigns/list.html
+++ b/src/bemserver_ui/templates/pages/campaigns/list.html
@@ -68,7 +68,7 @@
                                 {% if is_campaign_selected %}
                                 <div><small class="text-opacity-50 text-primary fst-italic"><i class="bi bi-info-square"></i> This campaign is currently selected as the working context.</small></div>
                                 {% endif %}
-                                <div class="text-muted ms-2">{{ x.description }}</div>
+                                <div class="text-muted multiline ms-2">{{ x.description | crlf2html }}</div>
                             </div>
                             <div class="v-stack">
                                 <div class="d-md-flex d-grid align-items-center gap-md-2">

--- a/src/bemserver_ui/templates/pages/campaigns/view.html
+++ b/src/bemserver_ui/templates/pages/campaigns/view.html
@@ -92,7 +92,7 @@
                             <dt>Until</dt>
                             <dd>{{ campaign.end_time | iso_datetime_format(tz_name=campaign.timezone, default="not defined") }}</dd>
                             <dt>Description</dt>
-                            <dd class="text-break">{{ campaign.description | default("-", true) }}</dd>
+                            <dd class="text-break multiline">{{ campaign.description | crlf2html | default("-", true) }}</dd>
                         </dl>
                         <div>
                             {% if signed_user.is_admin %}
@@ -115,7 +115,7 @@
                             <i class="bi bi-bounding-box-circles"></i>
                             <div class="d-grid">
                                 <h6 class="fw-bold text-nowrap mb-0">{{ x.name }}</h6>
-                                <small class="text-muted">{{ x.description }}</small>
+                                <small class="text-muted multiline">{{ x.description | crlf2html }}</small>
                             </div>
                         </a>
                         {% endfor %}

--- a/src/bemserver_ui/templates/pages/events/categories/edit.html
+++ b/src/bemserver_ui/templates/pages/events/categories/edit.html
@@ -26,7 +26,7 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label" for="description">Description</label>
-                    <textarea form="editForm" class="form-control" id="description" name="description" maxlength="250" rows="3">{{ event_category.description }}</textarea>
+                    <textarea form="editForm" class="form-control" id="description" name="description" maxlength="250" rows="3">{{ event_category.description | crlf2html }}</textarea>
                 </div>
                 <div class="d-flex justify-content-end gap-2">
                     <a href="{{ url_for('events.categories.list') }}" class="btn btn-outline-secondary btn-sm text-break" title="Cancel">Cancel</a>

--- a/src/bemserver_ui/templates/pages/events/categories/list.html
+++ b/src/bemserver_ui/templates/pages/events/categories/list.html
@@ -26,7 +26,7 @@
                         <i class="bi bi-tag"></i>
                         <h6 class="fw-bold text-break mb-0">{{ x.name }}</h6>
                     </div>
-                    <span class="fst-italic text-muted">{{ x.description }}</span>
+                    <span class="fst-italic text-muted multiline">{{ x.description | crlf2html }}</span>
                 </a>
                 {% endfor %}
             </div>

--- a/src/bemserver_ui/templates/pages/events/edit.html
+++ b/src/bemserver_ui/templates/pages/events/edit.html
@@ -79,7 +79,7 @@
                         </div>
                         <div class="mb-3">
                             <label class="form-label" for="description">Description</label>
-                            <textarea form="editForm" class="form-control" id="description" name="description" rows="4">{{ event.description }}</textarea>
+                            <textarea form="editForm" class="form-control" id="description" name="description" rows="4">{{ event.description | crlf2html }}</textarea>
                         </div>
                         <div class="d-flex justify-content-end gap-2">
                             <form id="editForm" action="{{ url_for('events.edit', id=event.id) }}" method="POST">

--- a/src/bemserver_ui/templates/pages/stats.html
+++ b/src/bemserver_ui/templates/pages/stats.html
@@ -16,7 +16,7 @@
                 </h5>
                 <div class="card-body text-end">
                     <span class="d-block fw-bold text-{% if g.campaign_ctxt.campaign['state'] == 'ongoing' %}success{% else %}muted{% endif %}">{{ g.campaign_ctxt.campaign["state"] }}</span>
-                    <small class="d-block text-muted">{{ g.campaign_ctxt.campaign["description"] }}</small>
+                    <small class="d-block text-muted text-break multiline">{{ g.campaign_ctxt.campaign["description"] | crlf2html }}</small>
                 </div>
                 <div class="card-body d-flex flex-wrap justify-content-center align-content-center gap-3">
                     {% if signed_user.is_admin %}

--- a/src/bemserver_ui/templates/pages/structural_elements/edit.html
+++ b/src/bemserver_ui/templates/pages/structural_elements/edit.html
@@ -54,7 +54,7 @@
                         {% endif %}
                         <div class="mb-3">
                             <label class="form-label" for="description">Description</label>
-                            <textarea form="editForm" class="form-control" id="description" name="description" maxlength="500" rows="3">{{ structural_element.description }}</textarea>
+                            <textarea form="editForm" class="form-control" id="description" name="description" maxlength="500" rows="3">{{ structural_element.description | crlf2html }}</textarea>
                         </div>
                         <div class="mb-3">
                             <label class="form-label" for="ifc_id">IFC ID</label>
@@ -157,5 +157,8 @@
 {{ super() -}}
 {% filter indent(width=8, first=True) %}
 <script type="module" src="{{ url_for('static', filename='scripts/modules/views/structuralElements/edit.js') }}" defer></script>
+<!-- <script>
+    document.getElementById("description").value = "{{ structural_element.description }}";
+</script> -->
 {% endfilter %}
 {% endblock body_scripts %}

--- a/src/bemserver_ui/templates/pages/structural_elements/properties/edit.html
+++ b/src/bemserver_ui/templates/pages/structural_elements/properties/edit.html
@@ -39,7 +39,7 @@
                 <div class="row mb-3">
                     <div class="col">
                         <label class="form-label" for="description">Description</label>
-                        <textarea form="editForm" class="form-control" id="description" name="description" maxlength="500" rows="3">{{ property.description }}</textarea>
+                        <textarea form="editForm" class="form-control" id="description" name="description" maxlength="500" rows="3">{{ property.description | crlf2html }}</textarea>
                     </div>
                 </div>
                 {% if structural_elements|length > 0 %}

--- a/src/bemserver_ui/templates/pages/structural_elements/properties/list.html
+++ b/src/bemserver_ui/templates/pages/structural_elements/properties/list.html
@@ -79,9 +79,9 @@
                             <td>{{ prop.unit_symbol }}</td>
                             <td>
                                 {% if prop.description|length > 80 %}
-                                <abbr title="{{ prop.description }}">{{ prop.description | truncate(80) }}</abbr>
+                                <abbr title="{{ prop.description | crlf2html }}" class="multiline">{{ prop.description | truncate(80) }}</abbr>
                                 {% else %}
-                                {{ prop.description }}
+                                <span class="multiline">{{ prop.description }}</span>
                                 {% endif %}
                             </td>
                             {% for struct_elmt in structural_elements %}

--- a/src/bemserver_ui/templates/pages/timeseries/edit.html
+++ b/src/bemserver_ui/templates/pages/timeseries/edit.html
@@ -53,7 +53,7 @@
                         </div>
                         <div class="mb-3">
                             <label class="form-label" for="description">Description</label>
-                            <textarea form="editForm" class="form-control" id="description" name="description" maxlength="500" rows="3">{{ timeseries.description }}</textarea>
+                            <textarea form="editForm" class="form-control" id="description" name="description" maxlength="500" rows="3">{{ timeseries.description | crlf2html }}</textarea>
                         </div>
                         <div class="mb-3">
                             <label class="form-label" for="unit_symbol">Unit symbol</label>

--- a/src/bemserver_ui/templates/pages/timeseries/list.html
+++ b/src/bemserver_ui/templates/pages/timeseries/list.html
@@ -218,7 +218,7 @@
                             <div class="tab-content overflow-auto border border-top-0 bg-white mb-3">
                                 <div class="tab-pane fade show active p-3" id="general-tabcontent-{{ x.id }}" role="tabpanel" aria-labelledby="general-tab-{{ x.id }}">
                                     <div class="d-flex justify-content-between align-items-start gap-3 mb-2">
-                                        <small>{{ x.description }}</small>
+                                        <small class="multiline">{{ x.description | crlf2html }}</small>
                                         {% if signed_user.is_admin %}
                                         <a class="btn btn-sm btn-outline-secondary text-nowrap" href="{{ url_for('timeseries.edit', id=x.id) }}" title="Edit"><i class="bi bi-pencil"></i> Edit</a>
                                         {% endif %}

--- a/src/bemserver_ui/templates/pages/timeseries/properties/edit.html
+++ b/src/bemserver_ui/templates/pages/timeseries/properties/edit.html
@@ -39,7 +39,7 @@
                 <div class="row mb-3">
                     <div class="col">
                         <label class="form-label" for="description">Description</label>
-                        <textarea form="editForm" class="form-control" id="description" name="description" maxlength="250" rows="3">{{ property.description }}</textarea>
+                        <textarea form="editForm" class="form-control" id="description" name="description" maxlength="250" rows="3">{{ property.description | crlf2html }}</textarea>
                     </div>
                 </div>
                 <div class="d-flex justify-content-end gap-2">

--- a/src/bemserver_ui/templates/pages/timeseries/properties/list.html
+++ b/src/bemserver_ui/templates/pages/timeseries/properties/list.html
@@ -35,10 +35,10 @@
                             <td>{{ prop.value_type }}</td>
                             <td>{{ prop.unit_symbol }}</td>
                             <td>
-                                {% if prop.description|length > 80 %}
-                                <abbr title="{{ prop.description }}">{{ prop.description | truncate(80) }}</abbr>
+                                {% if prop.description | length > 80 %}
+                                <abbr title="{{ prop.description | crlf2html }}" class="multiline">{{ prop.description | truncate(80) }}</abbr>
                                 {% else %}
-                                {{ prop.description }}
+                                <span class="multiline">{{ prop.description }}</span>
                                 {% endif %}
                             </td>
                             <td class="text-center"><a class="btn btn-sm btn-outline-secondary" href="{{ url_for('timeseries.properties.edit', id=prop.id) }}" title="Edit attribute"><i class="bi bi-pencil"></i></td>


### PR DESCRIPTION
Fixes 2 bugs:

- the newline characters are removed when a multi-line description is displayed
- when editing an object with a multi-line description (in a textarea) the newline characters appear, but there also seems to be extra left padding on subsequent lines