### PR TITLE
Fix ts explore add series button

### DIFF
--- a/src/bemserver_ui/static/scripts/modules/components/timeseries/selector.js
+++ b/src/bemserver_ui/static/scripts/modules/components/timeseries/selector.js
@@ -428,6 +428,8 @@ export class TimeseriesSelector extends HTMLElement {
                     break;
                 }
             }
+
+            this.#dispatchSelectionChanged();
         });
 
         this.#unselectAllResultsBtnElmt.addEventListener("click", (event) => {
@@ -442,6 +444,8 @@ export class TimeseriesSelector extends HTMLElement {
                 item.unselect(false);
                 this.#updateSelection(item, false);
             }
+
+            this.#dispatchSelectionChanged();
         });
 
         this.#clearAllSelectionBtnElmt.addEventListener("click", (event) => {
@@ -515,6 +519,11 @@ export class TimeseriesSelector extends HTMLElement {
         this.#dropdownSearchBtnElmt.addEventListener("hidden.bs.dropdown", () => {
             this.#isOpened = false;
         });
+    }
+
+    #dispatchSelectionChanged() {
+        let selectionChangedEvent = new CustomEvent("selectionChanged", { bubbles: true});
+        this.dispatchEvent(selectionChangedEvent);
     }
 
     #updateSearchInput() {
@@ -770,7 +779,7 @@ export class TimeseriesSelector extends HTMLElement {
             searchResultItem?.unselect(false);
 
             this.#selectedItemElmts = this.#selectedItemElmts.filter(x => x.timeseries.id != selectedItem.timeseries.id);
-            this.#updateSelectedItemsCounter();
+            this.#update();
 
             let eventDetail = { timeseries: selectedItem.timeseries };
             let removeEvent = new CustomEvent("removeItem", { detail: eventDetail, bubbles: true});

--- a/src/bemserver_ui/static/scripts/modules/views/timeseries/data/explore.js
+++ b/src/bemserver_ui/static/scripts/modules/views/timeseries/data/explore.js
@@ -134,12 +134,19 @@ class TimeseriesDataExploreView {
         });
 
         this.#tsSelector.addEventListener("toggleItem", () => {
-            if (this.#tsSelector.selectedItems.length > 0) {
-                this.#selectedTimeseriesSaveBtnElmt.removeAttribute("disabled");
-            }
-            else {
-                this.#selectedTimeseriesSaveBtnElmt.setAttribute("disabled", true);
-            }
+            this.#updateAddTimeseriesButtonState();
+        });
+
+        this.#tsSelector.addEventListener("removeItem", () => {
+            this.#updateAddTimeseriesButtonState();
+        });
+
+        this.#tsSelector.addEventListener("selectionChanged", () => {
+            this.#updateAddTimeseriesButtonState();
+        });
+
+        this.#tsSelector.addEventListener("clearSelection", () => {
+            this.#updateAddTimeseriesButtonState();
         });
 
         this.#selectedTimeseriesSaveBtnElmt.addEventListener("click", () => {
@@ -261,6 +268,15 @@ class TimeseriesDataExploreView {
                 },
             );
         });
+    }
+
+    #updateAddTimeseriesButtonState() {
+        if (this.#tsSelector.selectedItems.length > 0) {
+            this.#selectedTimeseriesSaveBtnElmt.removeAttribute("disabled");
+        }
+        else {
+            this.#selectedTimeseriesSaveBtnElmt.setAttribute("disabled", true);
+        }
     }
 
     #addTimeseries(timeseriesList, seriesYAxisPosition = "left", seriesType = "line") {


### PR DESCRIPTION
In some cases the add series button stays enable or disable while it should be in the other state.
This PR ensure that the button has the good state depending on what is done in timeseries selection component.